### PR TITLE
Improve mobile WebRTC resiliency and add resync/action relay support

### DIFF
--- a/Server/server.js
+++ b/Server/server.js
@@ -589,6 +589,52 @@ io.on('connection', (socket) => {
       return;
     }
 
+    if (type === 'lobby:request-resync') {
+      const { lobbyCode } = clients.get(socket.id) || {};
+      if (!lobbyCode || !lobbies.has(lobbyCode)) {
+        log(`[ERREUR RESYNC] Client ${clientId} demande resync sans lobby actif`);
+        send(socket, { type: 'lobby:error', payload: { message: 'Lobby introuvable pour resync.' } });
+        return;
+      }
+      const lobby = lobbies.get(lobbyCode);
+      const hostSocket = socketsById.get(lobby.hostId);
+      send(hostSocket, {
+        type: 'lobby:request-resync',
+        payload: { playerId: clientId }
+      });
+      return;
+    }
+
+    if (type === 'state:sync') {
+      const targetId = payload?.targetId;
+      const targetSocket = socketsById.get(targetId);
+      if (!targetSocket) {
+        log(`[ERREUR RESYNC] État sync vers ${targetId} échoué: destinataire introuvable`);
+        return;
+      }
+      send(targetSocket, {
+        type: 'state:sync',
+        payload: payload?.payload
+      });
+      return;
+    }
+
+    if (type === 'action:relay') {
+      const { lobbyCode } = clients.get(socket.id) || {};
+      if (!lobbyCode || !lobbies.has(lobbyCode)) {
+        log(`[ERREUR ACTION] Client ${clientId} envoie action sans lobby actif`);
+        send(socket, { type: 'lobby:error', payload: { message: 'Lobby introuvable pour action.' } });
+        return;
+      }
+      const lobby = lobbies.get(lobbyCode);
+      const hostSocket = socketsById.get(lobby.hostId);
+      send(hostSocket, {
+        type: 'action:relay',
+        payload: { fromId: clientId, action: payload?.action }
+      });
+      return;
+    }
+
     // Message non reconnu
     log(`[AVERTISSEMENT] ClientId: ${clientId}, Type de message non reconnu: ${type}`);
     send(socket, { 


### PR DESCRIPTION
### Motivation
- Reduce breakage for mobile clients by consolidating communication paths and providing automatic reconnection when WebRTC or socket connectivity is lost.
- Ensure clients that briefly lose connectivity (or leave and return to the page) can rejoin and get a fresh authoritative state from the host.
- Provide a socket-based fallback for actions and state sync when direct peer data channels are unavailable.
- Allow optional TURN configuration to improve WebRTC performance on restrictive networks.

### Description
- Client updates in `Application/src/services/GameSessionService.ts`: added `reconnectAttempts`, `rejoinInFlight`, visibility and `beforeunload` handlers, socket transports, and a `getIceServers` helper that reads TURN env vars.
- Added reconnection/resync logic on the client including `requestResync`, `handleResyncRequest`, `sendStateToSocket`, `schedulePeerReconnect`, `restartPeerConnection`, `handlePeerConnectionIssue`, and an `attemptRejoin` flow triggered on socket reconnect.
- Improved data channel and peer connection handling by observing connection/ICE state changes, clearing reconnect attempts when channels open, and cleaning up connections via `cleanupConnections`.
- Server updates in `Server/server.js`: added handlers to relay `lobby:request-resync`, `state:sync`, and `action:relay` messages so the host can provide state over the signaling channel when WebRTC is unavailable.

### Testing
- No automated tests were executed for this change.
- The changes were committed locally after applying the patches without running CI or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963f298739c8321a3eb8fb5dee462fc)